### PR TITLE
Add salary field to job postings and display it on prospect cards

### DIFF
--- a/client/src/components/add-prospect-form.tsx
+++ b/client/src/components/add-prospect-form.tsx
@@ -36,6 +36,7 @@ export function AddProspectForm({ onSuccess }: { onSuccess?: () => void }) {
       jobUrl: "",
       status: "Bookmarked",
       interestLevel: "Medium",
+      salary: "",
       notes: "",
     },
   });
@@ -156,6 +157,25 @@ export function AddProspectForm({ onSuccess }: { onSuccess?: () => void }) {
             )}
           />
         </div>
+
+        <FormField
+          control={form.control}
+          name="salary"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Salary (optional)</FormLabel>
+              <FormControl>
+                <Input
+                  placeholder="e.g. 120000"
+                  {...field}
+                  value={field.value ?? ""}
+                  data-testid="input-salary"
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
 
         <FormField
           control={form.control}

--- a/client/src/components/edit-prospect-form.tsx
+++ b/client/src/components/edit-prospect-form.tsx
@@ -41,6 +41,7 @@ export function EditProspectForm({ prospect, onSuccess }: EditProspectFormProps)
       jobUrl: prospect.jobUrl ?? "",
       status: prospect.status as InsertProspect["status"],
       interestLevel: prospect.interestLevel as InsertProspect["interestLevel"],
+      salary: prospect.salary ?? "",
       notes: prospect.notes ?? "",
     },
   });
@@ -160,6 +161,25 @@ export function EditProspectForm({ prospect, onSuccess }: EditProspectFormProps)
             )}
           />
         </div>
+
+        <FormField
+          control={form.control}
+          name="salary"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Salary (optional)</FormLabel>
+              <FormControl>
+                <Input
+                  placeholder="e.g. 120000"
+                  {...field}
+                  value={field.value ?? ""}
+                  data-testid="input-edit-salary"
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
 
         <FormField
           control={form.control}

--- a/client/src/components/prospect-card.tsx
+++ b/client/src/components/prospect-card.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import type { Prospect } from "@shared/schema";
 import { Button } from "@/components/ui/button";
-import { ExternalLink, Trash2, Pencil, Flame, ThumbsUp, Minus } from "lucide-react";
+import { ExternalLink, Trash2, Pencil, Flame, ThumbsUp, Minus, DollarSign } from "lucide-react";
 import { useMutation } from "@tanstack/react-query";
 import { apiRequest, queryClient } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
@@ -105,6 +105,19 @@ export function ProspectCard({ prospect }: { prospect: Prospect }) {
 
         <div className="flex items-center gap-1.5 flex-wrap">
           <InterestIndicator level={prospect.interestLevel} />
+        </div>
+
+        <div className="flex items-center gap-1" data-testid={`text-salary-${prospect.id}`}>
+          <DollarSign className={`w-3 h-3 ${prospect.salary ? "text-emerald-500" : "text-red-500"}`} />
+          {prospect.salary ? (
+            <span className="text-xs font-medium text-emerald-600 dark:text-emerald-400">
+              {prospect.salary}
+            </span>
+          ) : (
+            <span className="text-xs font-medium text-red-500 dark:text-red-400">
+              No salary listed
+            </span>
+          )}
         </div>
 
         {prospect.jobUrl && (

--- a/replit.md
+++ b/replit.md
@@ -30,7 +30,7 @@ client/src/
 
 ## Database
 
-Single `prospects` table: id, company_name, role_title, job_url, status, interest_level, notes, created_at.
+Single `prospects` table: id, company_name, role_title, job_url, status, interest_level, salary, notes, created_at.
 
 - **Statuses**: Bookmarked, Applied, Phone Screen, Interviewing, Offer, Rejected, Withdrawn
 - **Interest levels**: High, Medium, Low

--- a/server/__tests__/prospect-validation.test.ts
+++ b/server/__tests__/prospect-validation.test.ts
@@ -20,4 +20,58 @@ describe("prospect creation validation", () => {
     expect(result.valid).toBe(false);
     expect(result.errors).toContain("Role title is required");
   });
+
+  test("accepts a valid prospect with salary", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "Software Engineer",
+      salary: "150000",
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("accepts a valid prospect without salary", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "Software Engineer",
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("rejects a non-string salary", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "Software Engineer",
+      salary: 12345,
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Salary must be a text value");
+  });
+
+  test("rejects an invalid status", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "Software Engineer",
+      status: "InvalidStatus",
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toMatch(/Status must be one of/);
+  });
+
+  test("rejects an invalid interest level", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "Software Engineer",
+      interestLevel: "VeryHigh",
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toMatch(/Interest level must be one of/);
+  });
 });

--- a/server/prospect-helpers.ts
+++ b/server/prospect-helpers.ts
@@ -39,6 +39,12 @@ export function validateProspect(data: Record<string, unknown>): { valid: boolea
     }
   }
 
+  if (data.salary !== undefined && data.salary !== null) {
+    if (typeof data.salary !== "string") {
+      errors.push("Salary must be a text value");
+    }
+  }
+
   return { valid: errors.length === 0, errors };
 }
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -38,6 +38,12 @@ export async function registerRoutes(
     if (body.companyName !== undefined) updates.companyName = body.companyName;
     if (body.roleTitle !== undefined) updates.roleTitle = body.roleTitle;
     if (body.jobUrl !== undefined) updates.jobUrl = body.jobUrl;
+    if (body.salary !== undefined) {
+      if (body.salary !== null && typeof body.salary !== "string") {
+        return res.status(400).json({ message: "Salary must be a text value" });
+      }
+      updates.salary = body.salary === "" ? null : body.salary;
+    }
     if (body.notes !== undefined) updates.notes = body.notes;
 
     if (body.status !== undefined) {

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -21,6 +21,7 @@ export const prospects = pgTable("prospects", {
   jobUrl: text("job_url"),
   status: text("status").notNull().default("Bookmarked"),
   interestLevel: text("interest_level").notNull().default("Medium"),
+  salary: text("salary"),
   notes: text("notes"),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
 });
@@ -34,6 +35,7 @@ export const insertProspectSchema = createInsertSchema(prospects).omit({
   status: z.enum(STATUSES).default("Bookmarked"),
   interestLevel: z.enum(INTEREST_LEVELS).default("Medium"),
   jobUrl: z.string().optional().nullable(),
+  salary: z.string().optional().nullable(),
   notes: z.string().optional().nullable(),
 });
 


### PR DESCRIPTION
Adds a new `salary` field to the `prospects` table, updates the client-side forms and prospect card to display and edit the salary, and includes validation for the new field on both the client and server.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: f04f6b64-6cca-420a-a102-8a6c70d50fea
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Event-Id: 08e21506-5625-419d-bcb0-61d63ad5bb4f
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/e3ea2f54-7cce-4a40-af56-54b9efab21ae/f04f6b64-6cca-420a-a102-8a6c70d50fea/L0GoDEP
Replit-Helium-Checkpoint-Created: true